### PR TITLE
fix: Setting problem detail's type member to "about:blank"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/otaxhu/problem
 
-go 1.22.0
+go 1.23.3
 
-retract (
-    v1.0.0 // NewMap returned a pointer, changed to return not a pointer
-)
+retract v1.0.0 // NewMap returned a pointer, changed to return not a pointer
+
+require github.com/otaxhu/type-mismatch-encoding v0.0.0-20241117172253-59bedb66f7cd

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/otaxhu/type-mismatch-encoding v0.0.0-20241117172253-59bedb66f7cd h1:zrO/DhXnoBqI8oK1wbgxT+3rWXTI0UPYd2A3z6hzkOM=
+github.com/otaxhu/type-mismatch-encoding v0.0.0-20241117172253-59bedb66f7cd/go.mod h1:I7A2jI8mxo2WCUaaDnzo+Bso12DxLs4lERe+R6M09/Y=

--- a/registered.go
+++ b/registered.go
@@ -58,6 +58,10 @@ func (r *RegisteredProblem) setStatus(status int) {
 	r.Status = status
 }
 
+func (r *RegisteredProblem) setTypeAboutBlank() {
+	r.Type = "about:blank"
+}
+
 // Problem details map, this implementation is ONLY suitable for JSON marshaling/unmarshaling,
 // it does not support XML.
 //
@@ -98,4 +102,8 @@ func (m MapProblem) GetInstance() string {
 
 func (m MapProblem) setStatus(status int) {
 	m["status"] = status
+}
+
+func (m MapProblem) setTypeAboutBlank() {
+	m["type"] = "about:blank"
 }

--- a/registered.go
+++ b/registered.go
@@ -31,6 +31,9 @@ type RegisteredProblem struct {
 	Instance string `json:"instance" xml:"instance"`
 }
 
+// RegisteredProblem implements Problem
+var _ Problem = (*RegisteredProblem)(nil)
+
 func (r RegisteredProblem) GetType() string {
 	return r.Type
 }
@@ -64,6 +67,9 @@ func (r *RegisteredProblem) setStatus(status int) {
 //
 //	mapProblem["extension_member"]
 type MapProblem map[string]any
+
+// MapProblem implements Problem
+var _ Problem = (MapProblem)(nil)
 
 func (m MapProblem) GetType() string {
 	v, _ := m["type"].(string)


### PR DESCRIPTION
Closing #14

When type member is not present, or the JSON type is other than string, we are setting Type to "about:blank" when we call `ParseResponse...()` functions.